### PR TITLE
chore: change go.mod minor version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,11 @@
 module github.com/nuonco/nuon-go
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/go-openapi/errors v0.20.4
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7
-	github.com/go-openapi/swag v0.22.4
-	github.com/go-openapi/validate v0.22.1
 	github.com/go-playground/validator/v10 v10.15.3
 	github.com/go-swagger/go-swagger v0.30.5
 	github.com/golang/mock v1.4.4
@@ -29,6 +27,8 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/loads v0.21.2 // indirect
 	github.com/go-openapi/spec v0.20.9 // indirect
+	github.com/go-openapi/swag v0.22.4 // indirect
+	github.com/go-openapi/validate v0.22.1 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect


### PR DESCRIPTION
This updates the the `go.mod` to remove the minor version, as that will force any consumers to add a minor version as well.
