### PR TITLE
chore: remove slack webhook url

### DIFF
--- a/models/app_app.go
+++ b/models/app_app.go
@@ -59,9 +59,6 @@ type AppApp struct {
 	// sandbox config
 	SandboxConfig *AppAppSandboxConfig `json:"sandbox_config,omitempty"`
 
-	// slack webhook url
-	SlackWebhookURL string `json:"slack_webhook_url,omitempty"`
-
 	// status
 	Status string `json:"status,omitempty"`
 


### PR DESCRIPTION
Removing an old field on the app object.
