### PR TITLE
feat: Return Install Workflow ID to consumers after CreateInstall

### DIFF
--- a/client.go
+++ b/client.go
@@ -110,7 +110,7 @@ type Client interface {
 	GetVCSConnection(ctx context.Context, connID string) (*models.AppVCSConnection, error)
 
 	// installs
-	CreateInstall(ctx context.Context, appID string, req *models.ServiceCreateInstallRequest) (*models.AppInstall, error)
+	CreateInstall(ctx context.Context, appID string, req *models.ServiceCreateInstallRequest) (*models.AppInstall, string, error)
 	GetAppInstalls(ctx context.Context, appID string, query *models.GetPaginatedQuery) ([]*models.AppInstall, bool, error)
 	GetAllInstalls(ctx context.Context, query *models.GetPaginatedQuery) ([]*models.AppInstall, bool, error)
 

--- a/installs.go
+++ b/installs.go
@@ -4,22 +4,47 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-openapi/runtime"
 	"github.com/nuonco/nuon-go/client/operations"
 	"github.com/nuonco/nuon-go/models"
 )
 
+const (
+	HeaderInstallWorkflowID = "X-Nuon-Install-Workflow-ID"
+)
+
+type responseHeaderReader struct {
+	resp       runtime.ClientResponse
+	downstream runtime.ClientResponseReader
+}
+
+func (r *responseHeaderReader) ReadResponse(cRes runtime.ClientResponse, con runtime.Consumer) (interface{}, error) {
+	r.resp = cRes
+	return r.downstream.ReadResponse(cRes, con)
+}
+
+func (r *responseHeaderReader) GetHeader(key string) string {
+	return r.resp.GetHeader(key)
+}
+
 // installs
-func (c *client) CreateInstall(ctx context.Context, appID string, req *models.ServiceCreateInstallRequest) (*models.AppInstall, error) {
+func (c *client) CreateInstall(ctx context.Context, appID string, req *models.ServiceCreateInstallRequest) (*models.AppInstall, string, error) {
+	hr := &responseHeaderReader{
+		downstream: &operations.CreateInstallReader{},
+	}
+
 	resp, err := c.genClient.Operations.CreateInstall(&operations.CreateInstallParams{
 		AppID:   appID,
 		Req:     req,
 		Context: ctx,
-	}, c.getOrgIDAuthInfo())
+	}, c.getOrgIDAuthInfo(), func(co *runtime.ClientOperation) { co.Reader = hr })
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return resp.Payload, nil
+	installWOrkflowID := hr.GetHeader(HeaderInstallWorkflowID)
+
+	return resp.Payload, installWOrkflowID, nil
 }
 
 func (c *client) GetAppInstalls(ctx context.Context, appID string, query *models.GetPaginatedQuery) ([]*models.AppInstall, bool, error) {


### PR DESCRIPTION
The Install Workflow ID is returned as a header. Extracting and returning the headers required some plumbing, but the `ResponseReader` can be reused in other places to access headers as well.