### PR TITLE
fix: Add missing method signature to Client interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -126,6 +126,9 @@ type Client interface {
 	CreateInstallConfig(ctx context.Context, installID string, req *models.ServiceCreateInstallConfigRequest) (*models.AppInstallConfig, error)
 	UpdateInstallConfig(ctx context.Context, installID, configID string, req *models.ServiceUpdateInstallConfigRequest) (*models.AppInstallConfig, error)
 
+	// install cli config
+	GenerateCLIInstallConfig(ctx context.Context, installID string) ([]byte, error)
+
 	// install deploys
 	GetInstallDeploys(ctx context.Context, installID string, query *models.GetPaginatedQuery) ([]*models.AppInstallDeploy, bool, error)
 	CreateInstallDeploy(ctx context.Context, installID string, req *models.ServiceCreateInstallDeployRequest) (*models.AppInstallDeploy, error)


### PR DESCRIPTION
The `Client` interface was missing `GenerateInstallCLIConfig()` method on it. This patch fixes it.