### PR TITLE
chore: expose Recurse option in SDK

### DIFF
--- a/app_configs.go
+++ b/app_configs.go
@@ -20,11 +20,12 @@ func (c *client) GetAppConfigTemplate(ctx context.Context, appID string, typ mod
 	return resp.Payload, nil
 }
 
-func (c *client) GetAppConfig(ctx context.Context, appID, appConfigID string) (*models.AppAppConfig, error) {
+func (c *client) GetAppConfig(ctx context.Context, appID, appConfigID string, recurse *bool) (*models.AppAppConfig, error) {
 	resp, err := c.genClient.Operations.GetAppConfig(&operations.GetAppConfigParams{
 		AppID:       appID,
 		AppConfigID: appConfigID,
 		Context:     ctx,
+		Recurse:     recurse,
 	}, c.getOrgIDAuthInfo())
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -52,7 +52,7 @@ type Client interface {
 	GetAppConfigTemplate(ctx context.Context, appID string, typ models.ServiceAppConfigTemplateType) (*models.ServiceAppConfigTemplate, error)
 	CreateAppConfig(ctx context.Context, appID string, req *models.ServiceCreateAppConfigRequest) (*models.AppAppConfig, error)
 	UpdateAppConfigInstalls(ctx context.Context, appID, appConfigID string, req *models.ServiceUpdateAppConfigInstallsRequest) error
-	GetAppConfig(ctx context.Context, appID, appConfigID string) (*models.AppAppConfig, error)
+	GetAppConfig(ctx context.Context, appID, appConfigID string, recurse *bool) (*models.AppAppConfig, error)
 	GetAppLatestConfig(ctx context.Context, appID string) (*models.AppAppConfig, error)
 	GetAppConfigs(ctx context.Context, appID string, query *models.GetPaginatedQuery) ([]*models.AppAppConfig, bool, error)
 	UpdateAppConfig(ctx context.Context, appID, appConfigID string, req *models.ServiceUpdateAppConfigRequest) (*models.AppAppConfig, error)


### PR DESCRIPTION
This exposes the `recurse` option in the SDK for fetching an app-config.
